### PR TITLE
fix: Add ListFiles method to mockRDSClient in pool tests

### DIFF
--- a/pkg/rds/pool_test.go
+++ b/pkg/rds/pool_test.go
@@ -60,6 +60,10 @@ func (m *mockRDSClient) ListVolumes() ([]VolumeInfo, error) {
 	return nil, nil
 }
 
+func (m *mockRDSClient) ListFiles(path string) ([]FileInfo, error) {
+	return nil, nil
+}
+
 func (m *mockRDSClient) GetCapacity(basePath string) (*CapacityInfo, error) {
 	return nil, nil
 }


### PR DESCRIPTION
The pool_test.go mock client was missing the ListFiles method required by the RDSClient interface. This commit adds the method to satisfy the interface requirements.